### PR TITLE
ci: normalize + build feeds inside deploy workflow

### DIFF
--- a/.github/workflows/deploy-and-watch.yml
+++ b/.github/workflows/deploy-and-watch.yml
@@ -71,6 +71,11 @@ jobs:
           chmod +x scripts/deploy_cloud_run.sh
           ./scripts/deploy_cloud_run.sh
 
+      - name: Normalize + build feeds
+        run: |
+          python3 scripts/normalize_enriched.py || true
+          python3 scripts/build_trends_feeds.py || true
+
       - name: Smoke test (prod)
         run: |
           chmod +x scripts/smoke.sh


### PR DESCRIPTION
Run scripts/normalize_enriched.py and scripts/build_trends_feeds.py before smoke/validation to ensure validators read normalized data.