### PR TITLE
fix: normalize_enriched robustness + feed samples in validate step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,24 @@ jobs:
           make style-check
           python3 scripts/normalize_enriched.py || true
           make feeds
+          echo "::group::Feed sample (prod)"
+          if command -v jq >/dev/null 2>&1; then
+            echo "EN first:" && jq -c '.[0]' artifacts/feeds/trends.en.json || true
+            echo "FI first:" && jq -c '.[0]' artifacts/feeds/trends.fi.json || true
+          else
+            python - <<'PY' || true
+import json
+from pathlib import Path
+for p in [Path('artifacts/feeds/trends.en.json'), Path('artifacts/feeds/trends.fi.json')]:
+    if p.exists():
+        try:
+            data=json.loads(p.read_text())
+            print(f"{p.name} first={json.dumps(data[0]) if data else '[]'}")
+        except Exception as e:
+            print(f"{p}: error {e}")
+PY
+          fi
+          echo "::endgroup::"
           python3 scripts/validate_trends.py || true
           make validate-news
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,25 @@ jobs:
           make style-check
           python3 scripts/normalize_enriched.py || true
           make feeds
+          echo "::group::Feed sample (preview)"
+          if command -v jq >/dev/null 2>&1; then
+            echo "EN first:" && jq -c '.[0]' artifacts/feeds/trends.en.json || true
+            echo "FI first:" && jq -c '.[0]' artifacts/feeds/trends.fi.json || true
+          else
+            python - <<'PY' || true
+import json
+from pathlib import Path
+for p in [Path('artifacts/feeds/trends.en.json'), Path('artifacts/feeds/trends.fi.json')]:
+    if p.exists():
+        try:
+            data=json.loads(p.read_text())
+            print(f"{p.name} first={json.dumps(data[0]) if data else '[]'}")
+        except Exception as e:
+            print(f"{p}: error {e}")
+PY
+          fi
+          echo "::endgroup::"
+          python3 scripts/validate_trends.py || true
           make validate-news
 
       # Generate duotone imgs


### PR DESCRIPTION
- Handle list/dict shapes in normalize_enriched and preserve shape\n- Ensure required fields (lede, why_it_matters, who_benefits, _meta.category, image_base)\n- Print EN/FI first card sample in deploy validate step for debugging